### PR TITLE
add IP clients counter and NCP position to EQ init

### DIFF
--- a/conf.h
+++ b/conf.h
@@ -96,3 +96,5 @@
 //On slow pulse detect stepper driver as DRV8825 comment out
 #define AZ_P_DELAY 23
 #define ALT_P_DELAY 23
+// Use NCP as default position for EQ mount
+#define NCP_HOME

--- a/esp32go.ino
+++ b/esp32go.ino
@@ -46,6 +46,7 @@ extern int8_t focusinv;
 extern int focusvolt;
 WiFiServer server(SERVER_PORT);
 WiFiClient serverClients[MAX_SRV_CLIENTS];
+int clients_connected = 0;
 
 BluetoothSerial SerialBT;
 WebServer serverweb(WEB_PORT);
@@ -151,10 +152,12 @@ int net_task(void)
     }
   }
   //check clients for data
+  clients_connected=0;
   for (i = 0; i < MAX_SRV_CLIENTS; i++)
   {
     if (serverClients[i] && serverClients[i].connected())
     {
+      clients_connected++;
       if (serverClients[i].available())
       {
         //get data from the  client and push it to LX200 FSM

--- a/mount.cpp
+++ b/mount.cpp
@@ -520,9 +520,15 @@ void mount_home_set(mount_t *mt)
       setpositionf(mt->altmotor, M_PI) ;
       break;
     case EQ:
+#ifdef NCP_HOME
+      setpositionf(mt->azmotor, M_PI / 2);
+      delay(10);
+      setpositionf(mt->altmotor, (M_PI / 2) + 5e-6);
+#else
       setpositionf(mt->azmotor, M_PI / 2 );
       delay(10);
       setpositionf(mt->altmotor, M_PI );
+#endif
       break;
   }
   //   save_counters(ALT_ID);

--- a/oled.cpp
+++ b/oled.cpp
@@ -4,6 +4,7 @@
 extern mount_t *telescope;
 SSD1306 display(0x3c, SDA_PIN, SCL_PIN);
 extern time_t now;
+extern int clients_connected;
 void oledDisplay()
 {
   char ra[20] = "";
@@ -14,25 +15,28 @@ void oledDisplay()
   // display.drawString(0, 13, String(buff) + "  " + String(response));
   lxprintra(ra, sidereal_timeGMT_alt(telescope->longitude) * 15.0 * DEG_TO_RAD);
   display.drawString(0, 9, "LST " + String(ra));
-  // lxprintra(ra, calc_Ra(telescope->azmotor->position, telescope->longitude));
-  // lxprintde(de, telescope->altmotor->position);
+   lxprintra(ra, calc_Ra(telescope->azmotor->position, telescope->longitude));
+   lxprintde(de, telescope->altmotor->position);
 
   display.drawString(0, 50, "RA:" + String(ra) + " DE:" + String(de));
   lxprintde(de, telescope->azmotor->delta);
-  display.drawString(0, 36, String(de)); // ctime(&now));
+  //display.drawString(0, 36, String(de)); // ctime(&now));
   display.drawString(0, 18, "MA:" + String(telescope->azmotor->counter) + " MD:" + String(telescope->altmotor->counter));
   //display.drawString(0, 27, "Dt:" + String(digitalRead(16)));//(telescope->azmotor->slewing));
- // display.drawString(0, 27, "Dt:" + String(digitalRead(16))) + " Rate:" + String(telescope->srate));
+  //display.drawString(0, 27, "Dt:" + String(digitalRead(13)) + " Rate:" + String(telescope->srate));
   //unsigned int n= pwd.length();
   //display.drawString(0, 32,String(pw)+ " "+ String(n));
   display.drawString(0, 0, ctime(&now));
+//---------
+  display.drawString(0, 36, "IP Clients: "+String(clients_connected));
+//---------  
   display.display();
 }
 void oled_initscr(void)
 
 {
   display.init();
-  //  display.flipScreenVertically();
+//    display.flipScreenVertically();
   display.setFont(ArialMT_Plain_10);
   display.setTextAlignment(TEXT_ALIGN_LEFT);
   display.clear();


### PR DESCRIPTION
- repasado oled.cpp y añadido contador como variable global en esp32.ino para mostrar las conexiones IP activas en el oled
- añadido #define NCP_HOME para que en modo EQ tome como home por defecto NCP