### PR TITLE
bugfix: correct dns value in dialog

### DIFF
--- a/webserver.cpp
+++ b/webserver.cpp
@@ -391,7 +391,7 @@ void handleNetwork( void)
   content += "<tr><td>IP</td><td><input type='text' name='IP' class=\"text_red\" value='" + WiFi.localIP().toString() + "'></td></td>";
   content += "<td><td>MASK</td><td><input type='test' name='MASK'class=\"text_red\"  value='" + WiFi.subnetMask().toString() + "'></td></tr>";
   content += "<tr><td>Gateway</td><td><input type='text' name='GATEWAY' class=\"text_red\" value='" + WiFi.gatewayIP().toString() + "'></td></td>";
-  content += "<td><td>DNS</td><td><input type='test' name='DNS' class=\"text_red\"  value='" + WiFi.gatewayIP().toString() + "'></td></tr>";
+  content += "<td><td>DNS</td><td><input type='test' name='DNS' class=\"text_red\"  value='" + WiFi.dnsIP().toString() + "'></td></tr>";
   content += "<tr><td>NAPT</td><td><input type='number' name='NAPT' class=\"text_red\" value='" + String(napt) + "'></td></td></tr></table>";
 
   content += "<input type='submit' name='SUBMIT'  class=\"button_red\" value='Save'></fieldset></form>" + msg + "<br>";


### PR DESCRIPTION
la interfaz de 'Network' estaba sobreescribiendo el valor del servidor DNS con el de Gateway si se guardaban los datos sin repasarlos