### PR TITLE
patch for nunchuck & oled co-existence

### DIFF
--- a/esp32go.ino
+++ b/esp32go.ino
@@ -343,6 +343,9 @@ void setup()
     pinMode(SDA_PIN, INPUT_PULLUP);
     pinMode(SCL_PIN, INPUT_PULLUP);
     nunchuck_init( SDA_PIN, SCL_PIN);
+  #ifdef OLED_DISPLAY
+    nunchuck_init( SDA_PIN, SCL_PIN); // si no se inicializa otra vez, no se detecta bien el nunchuck al inicio cuando esta el OLED activado
+  #endif
     nunchuck_disable(nunchuck_read() == 0);
 #endif
 #ifdef OTA


### PR DESCRIPTION
init twice for nunchuck to work when oled is connected. if not done, it does not get detected and you have to enable it from the web interface for it to work